### PR TITLE
Improve accessibility

### DIFF
--- a/lapreprint.cls
+++ b/lapreprint.cls
@@ -307,7 +307,7 @@
    \setlength{\parindent}{0pt}\raggedright
    \textcolor{MediumGrey}{\rule{\textwidth}{2pt}}
    \vskip16pt
-   \textcolor{lightColour}{\large\bfseries\abstractname\space}
+   \textcolor{darkColour}{\large\bfseries\abstractname\space}
 
    % Here we squeeze in the margin metadata
    \marginpar{\raggedright\footnotesize\themetadata\par}
@@ -539,7 +539,7 @@
   allcolors=black,
   citecolor=MediumGrey,
   linkcolor=MediumGrey,
-  urlcolor=lightColour,
+  urlcolor=darkColour,
   hypertexnames=false}
 \urlstyle{sf}
 

--- a/template.tex
+++ b/template.tex
@@ -12,11 +12,23 @@
 
 % Enable PDF accessibility tagging (PDF/UA-2) via the LaTeX Tagging Project.
 % Requires LuaLaTeX and TeX Live 2025+.
-% See https://latex3.github.io/tagging-project/documentation/usage-instructions
+% See
+% https://latex3.github.io/tagging-project/documentation/usage-instructions
+% https://github.com/rhstanton/accessible_LaTeX/blob/main/accessible_article.tex
 \DocumentMetadata{
-  tagging=on,
   lang=en,
+  pdfstandard=a-2u, % PDF/A-2u format (archival standard with Unicode support)
+  pdfstandard=ua-1, % Add PDF/UA-1 accessibility conformance target
   pdfstandard=ua-2,
+  pdfversion=1.7,   % Explicit PDF version used for compatibility with conformance tooling
+  testphase = {phase-III, table},
+  tagging=on,
+  tagging-setup={
+    math/alt/use,  % Keep math accessibility enabled (screen readers get tagged math)
+    math/mathml/AF=false, % Do not embed MathML as PDF Associated Files (helps some strict conformance checkers)
+    math/tex/AF=false,    % Do not embed TeX source as Associated Files
+    math/mathml/sources=  % Clear MathML source attachment list (avoid extra embedded helper files)
+  }
 }
 
 % Declare document class
@@ -58,6 +70,29 @@
 \usepackage{multirow}
 \usepackage{snotez}     % For sidenote environments. enotez for endnotes
 \usepackage{csquotes}   % For language-based quote rules (helps BiBLaTeX)
+\usepackage{unicode-math} % Unicode math fonts (provides \setmathfont + automatic MathML)
+\usepackage{xcolor}     % Color support (needed for accessibility-friendly colors)
+
+% ======================================================================
+% HYPERLINK CONFIGURATION
+% ======================================================================
+% Links should be both colored AND underlined for accessibility
+% Color alone is not sufficient (fails WCAG guidelines)
+
+\usepackage{url,hyperref}
+\urlstyle{same}  % URLs use the same font as surrounding text
+
+% Custom commands for underlined hyperlinks
+\newcommand{\hrefu}[2]{\href{#1}{\uline{#2}}}  % Hyperlink with underline
+\newcommand{\urlu}[1]{\uline{\url{#1}}}        % URL with underline
+
+% Set link colors (blue for consistency with heading color in slides)
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,   % Internal links (TOC, references)
+  urlcolor=blue,    % External URLs
+  citecolor=blue    % Citations
+}
 
 [-IMPORTS-]
 

--- a/template.tex
+++ b/template.tex
@@ -21,7 +21,6 @@
   pdfstandard=ua-1, % Add PDF/UA-1 accessibility conformance target
   pdfstandard=ua-2,
   pdfversion=1.7,   % Explicit PDF version used for compatibility with conformance tooling
-  testphase = {phase-III, table},
   tagging=on,
   tagging-setup={
     math/alt/use,  % Keep math accessibility enabled (screen readers get tagged math)
@@ -72,6 +71,8 @@
 \usepackage{csquotes}   % For language-based quote rules (helps BiBLaTeX)
 \usepackage{unicode-math} % Unicode math fonts (provides \setmathfont + automatic MathML)
 \usepackage{xcolor}     % Color support (needed for accessibility-friendly colors)
+\usepackage{float}      % Provides \floatplacement
+\floatplacement{table}{htbp} % Restore here-preferring placement; tagging=on changes the default
 
 % ======================================================================
 % HYPERLINK CONFIGURATION

--- a/template.tex
+++ b/template.tex
@@ -10,6 +10,15 @@
 %%% PREAMBLE
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Enable PDF accessibility tagging (PDF/UA-2) via the LaTeX Tagging Project.
+% Requires LuaLaTeX and TeX Live 2025+.
+% See https://latex3.github.io/tagging-project/documentation/usage-instructions
+\DocumentMetadata{
+  tagging=on,
+  lang=en,
+  pdfstandard=ua-2,
+}
+
 % Declare document class
 \documentclass[9pt
 [#- if options.venue_footer == "biorxiv" #],biorxiv[# endif -#]

--- a/template.yml
+++ b/template.yml
@@ -125,3 +125,6 @@ packages:
   - unicode-math
   - wrapfig
   - xcolor
+
+build:
+  engine: -lualatex


### PR DESCRIPTION
These changes improve accessibility scoring from two different accessibility checkers. The main differences are using lualatex instead of xetex and adding tags. I needed to install TeX Live 2025. I don't know LaTeX very well, and relied on @rhstanton's work in https://github.com/rhstanton/accessible_LaTeX/. All shortcomings are mine.

The tools I used to measure accessibility.

 1. [ally](https://ally.ac/), used within my institution's LMS, which scans uploaded PDFs
 2. [verapdf](https://verapdf.org/), used via docker
    ```shell
    myst build --pdf
    docker run --platform linux/amd64 --rm -it -v .:/data ghcr.io/verapdf/cli:latest \
      --format json -df ua2  --loglevel 0  \
      exports/myst-latex.pdf > verapdf-analysis.json
    ```

My local myst project referenced my local fork:
```yaml
version: 1

project:
  title: Accessibility Test
  authors:
    - name: Your Name
  exports:
    - format: pdf
      template: ../lapreprint
      output: exports/myst-latex.pdf
    - format: tex
      template: ../lapreprint
      output: exports/myst-latex.tex
  toc:
    - file: index.md

site:
  template: book-theme
```

My `index.md` test file contained:
```markdown
---
title: foo
authors:
  - name: Your Name
exports:
  - format: pdf
  - format: typst
---
+++ { "part": "abstract" }

This is a placeholder abstract.

+++

## Code

:::{code-cell} python
hello = "hello"
there = "there"
phrase = f"{hello}, {there}!"
print(phrase)
:::

## header 1

some math

$$
\int f(\theta)d\theta
$$

## header 2

:::{csv-table} a table
:header: "col1", "col2"

4, "a"
5, "b"
:::
```

(I tried several table variants besides `csv-table`.)


When I generated verapdf json output with the current lapreprint code and summarized with:
```shell
$ cat /tmp/myst-latex-upstream.json | jq '
      .report.jobs[0].validationResult[0]
      | { compliant, failed_rules: .details.failedRules, failed_checks: .details
.failedChecks }
    '
{
  "compliant": false,
  "failed_rules": 10,
  "failed_checks": 43
}
```

When I ran it with my changes:
```shell
$ $ cat /tmp/myst-latex-fixes.json | jq '
      .report.jobs[0].validationResult[0]
      | { compliant, failed_rules: .details.failedRules, failed_checks: .details
.failedChecks }
    '
{
  "compliant": false,
  "failed_rules": 1,
  "failed_checks": 4
}
```
 
The remaining failure is related to tables and tagging, and I believe that would need to be fixed in myst.

Cc: https://github.com/jupyter-book/mystmd/issues/2743

[myst-latex-upstream.pdf](https://github.com/user-attachments/files/25855040/myst-latex-upstream.pdf)
[myst-latex-fixes.pdf](https://github.com/user-attachments/files/25855041/myst-latex-fixes.pdf)

